### PR TITLE
fix: support multiple snapshots per test

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,18 +17,20 @@ module.exports = function toMatchSnapshot(received, mochaContext, name) {
 
   const snapshotFile = snapshotResolver.resolveSnapshotPath(test.file);
 
-  const snapshotState = new jestSnapshot.SnapshotState(snapshotFile, {
-    updateSnapshot: process.env.SNAPSHOT_UPDATE ? 'all' : 'new',
-  });
+  if (!mochaContext.snapshotState) {
+    mochaContext.snapshotState = new jestSnapshot.SnapshotState(snapshotFile, {
+      updateSnapshot: process.env.SNAPSHOT_UPDATE ? 'all' : 'new',
+    })
+  }
 
   const matcher = jestSnapshot.toMatchSnapshot.bind({
-    snapshotState,
+    snapshotState: mochaContext.snapshotState,
     currentTestName: makeTestTitle(test),
   });
 
   const result = matcher(received, name || '');
 
-  snapshotState.save();
+  mochaContext.snapshotState.save();
 
   return result;
 };


### PR DESCRIPTION
Current implementation always overwrites snapshots. This PR persists the snapshot state in the test context and thus allows multiple snapshots like in Jest.